### PR TITLE
chore: remove 'ruint' patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2570,22 +2570,22 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.8.0"
-source = "git+https://github.com/paradigmxyz/uint#38f565ff907ccaf2a2c57d395ed7c2b8905ae1ab"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e1574d439643c8962edf612a888e7cc5581bcdf36cb64e6bc88466b03b2daa"
 dependencies = [
- "derive_more",
  "primitive-types",
  "rlp",
  "ruint-macro",
- "rustc_version",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "ruint-macro"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/uint#38f565ff907ccaf2a2c57d395ed7c2b8905ae1ab"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,5 @@ tokio = "1.29.1"
 tokio-util = { version = "0.7.8", features = ["time"] }
 
 [patch.crates-io]
-ruint = { git = "https://github.com/paradigmxyz/uint" }
 revm = { git = "https://github.com/bluealloy/revm/", branch = "release/v25" }
 revm-primitives = { git = "https://github.com/bluealloy/revm/", branch = "release/v25" }


### PR DESCRIPTION
remove `ruint` patch from `Cargo.toml` given change [here](https://github.com/paradigmxyz/reth/pull/3910)