### PR TITLE
refactor: convert broadcast receiver into stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,7 @@ dependencies = [
  "reth-revm",
  "reth-revm-primitives",
  "tokio",
+ "tokio-stream",
  "tokio-util",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ reth-provider = { git = "https://github.com/paradigmxyz/reth.git", package = "re
 reth-revm = { git = "https://github.com/paradigmxyz/reth.git", package = "reth-revm" }
 reth-revm-primitives = { git = "https://github.com/paradigmxyz/reth.git", package = "reth-revm-primitives" }
 tokio = "1.29.1"
+tokio-stream = { version = "0.1.14", features = ["sync"] }
 tokio-util = { version = "0.7.8", features = ["time"] }
 
 [patch.crates-io]


### PR DESCRIPTION
convert broadcast receivers for incoming bundles and invalidated bundles into streams by wrapping with `BroadcastStream`

other:

* fuse streams so that `poll_next` does not cause issues even if the stream has terminated.
* if the broadcast stream lags, then just move on. we can emit a warning here when we resolve #24.