### PR TITLE
fix: mark bundle executed after all its txs execute

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -543,8 +543,10 @@ fn build_on_state<S: StateProvider, I: Iterator<Item = (BundleId, BundleCompact)
             total_fees += U256::from(miner_fee) * U256::from(result.gas_used());
 
             txs.push(tx.into_signed());
-            bundle_ids.insert(id);
         }
+
+        // add bundle to set of executed bundles
+        bundle_ids.insert(id);
     }
 
     // NOTE: here we assume post-shanghai


### PR DESCRIPTION
currently we (re)insert the bundle into the set of executed bundles after each transaction within the bundle executes. here, we correct the bundle tracking to only add the bundle to the set after all transactions in the bundle execute.