### PR TITLE
feat: add access list to execution result

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -30,9 +30,8 @@ use reth_payload_builder::{
 use reth_primitives::AccessListItem;
 use reth_primitives::{
     constants::{BEACON_NONCE, EMPTY_OMMER_ROOT},
-    proofs, AccessList, Address, Block, BlockNumber, Bytes, ChainSpec, Header,
-    IntoRecoveredTransaction, Receipt, SealedHeader, TransactionSigned,
-    TransactionSignedEcRecovered, U256,
+    proofs, AccessList, Block, BlockNumber, Bytes, ChainSpec, Header, IntoRecoveredTransaction,
+    Receipt, SealedHeader, TransactionSigned, TransactionSignedEcRecovered, U256,
 };
 use reth_provider::{
     BlockReaderIdExt, CanonStateNotification, PostState, StateProvider, StateProviderFactory,
@@ -941,12 +940,8 @@ fn proposer_payment_tx(
     tx.into_ecrecovered().expect("can recover tx signer")
 }
 
-fn precompiles(cfg_env: &CfgEnv) -> HashSet<Address> {
+fn precompiles(cfg_env: &CfgEnv) -> &Precompiles {
     Precompiles::new(PrecompileSpecId::from_spec_id(cfg_env.spec_id))
-        .addresses()
-        .into_iter()
-        .map(Address::from)
-        .collect()
 }
 
 #[cfg(test)]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -802,6 +802,7 @@ where
 
 #[derive(Clone, Debug)]
 struct Execution {
+    #[allow(dead_code)]
     access_list: AccessList,
     cumulative_gas_used: u64,
     coinbase_payment: U256,


### PR DESCRIPTION
add access list to execution result.

access list information will inform simulation strategies (i.e. bundle merging).