### PR TITLE
compute coinbase payment for execution

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -822,7 +822,7 @@ mod tests {
         assert_eq!(cumulative_gas_used, expected_cumulative_gas_used);
 
         // check coinbase payment
-        let expected_coinbase_payment = tx_gas_limit * max_priority_fee;
+        let expected_coinbase_payment = cumulative_gas_used * max_priority_fee;
         let builder_account = post_state
             .account(&Address::from(builder_wallet.address()))
             .expect("builder account touched")
@@ -913,7 +913,7 @@ mod tests {
         } = execution;
 
         // check coinbase payment
-        let expected_coinbase_payment = tx_value + (cumulative_gas_used * max_fee);
+        let expected_coinbase_payment = tx_value + (cumulative_gas_used * max_priority_fee);
         let builder_account = post_state
             .account(&Address::from(builder_wallet.address()))
             .expect("builder account touched")

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -686,19 +686,19 @@ fn package_block<S: StateProvider>(
 
 /// Computes the payment to `coinbase` based on `initial_balance` and `post_state`.
 ///
-/// NOTE: If the account has been deleted, then we mark the payment zero. if the account was not
-/// modified, then the payment will also be computed as zero.
+/// NOTE: If the ending balance is less than `initial_balance`, then we define the payment as zero.
+/// If the account has been deleted, then we define the payment as zero. If the account was not
+/// modified, then the payment will be zero.
 fn compute_coinbase_payment(
     coinbase: &B160,
     initial_balance: U256,
     post_state: &PostState,
 ) -> U256 {
-    let end_balance = match post_state.account(coinbase) {
-        Some(Some(acct)) => acct.balance,
+    match post_state.account(coinbase) {
+        Some(Some(acct)) => acct.balance.saturating_sub(initial_balance),
         Some(None) => U256::ZERO,
-        None => initial_balance,
-    };
-    end_balance.saturating_sub(initial_balance)
+        None => U256::ZERO,
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
add `coinbase_payment` field to `Execution` to track the payment to the block's `coinbase`, which we assume to represent the builder.

we compute `coinbase_payment` based on the pre and post execution balance of the account at address `coinbase`. this calculation includes priority fees (i.e. tips) and any other transfers to `coinbase`. among other things, the calculation does not account for expenditures from the `coinbase` account. subsequent changes can make the calculation more flexible/robust.