### PR TITLE
refactor: use evm error in execute result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3480,6 +3480,7 @@ dependencies = [
  "reth-interfaces",
  "reth-primitives",
  "reth-revm-primitives",
+ "reth-rlp",
  "reth-trie",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ revm-primitives = { git = "https://github.com/bluealloy/revm/", branch = "releas
 [dev-dependencies]
 ethers = "2.0.8"
 rand = "0.8.5"
+reth-provider = { git = "https://github.com/paradigmxyz/reth.git", package = "reth-provider", version = "0.1.0-alpha.6", features = ["test-utils"] }


### PR DESCRIPTION
use `EVMError` in `execute` result instead of `PayloadBuilderError`