### PR TITLE
ci: fix clippy warning and catch in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
 
 jobs:
   build:

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -769,7 +769,7 @@ where
 
     // compute the coinbase payment
     let coinbase_payment =
-        compute_coinbase_payment(&block_env.coinbase, initial_coinbase_balance, &post_state);
+        compute_coinbase_payment(&block_env.coinbase, initial_coinbase_balance, post_state);
 
     Ok(Execution {
         cumulative_gas_used,


### PR DESCRIPTION
fix a clippy warning present in previous CI runs, and add `RUSTFLAGS` value to CI environment so that CI fails on all warnings (including clippy lints)